### PR TITLE
Better Naming for display names

### DIFF
--- a/ar.lproj/Localizable.strings
+++ b/ar.lproj/Localizable.strings
@@ -27,7 +27,7 @@
 
 "COPY_PROFILE_INFO_MENU_OPTION_1" = "نسخ البايو";
 "COPY_PROFILE_INFO_MENU_OPTION_2" = "نسخ اسم المستخدم";
-"COPY_PROFILE_INFO_MENU_OPTION_3" = "نسخ اسم المستخدم كاملا";
+"COPY_PROFILE_INFO_MENU_OPTION_3" = "نسخ اسم العرض";
 "COPY_PROFILE_INFO_MENU_OPTION_4" = "نسخ رابط البايو";
 "COPY_PROFILE_INFO_MENU_OPTION_5" = "نسخ الموقع الجغرافي";
 

--- a/en.lproj/Localizable.strings
+++ b/en.lproj/Localizable.strings
@@ -27,7 +27,7 @@
 
 "COPY_PROFILE_INFO_MENU_OPTION_1" = "Copy bio";
 "COPY_PROFILE_INFO_MENU_OPTION_2" = "Copy Username";
-"COPY_PROFILE_INFO_MENU_OPTION_3" = "Copy Full Username";
+"COPY_PROFILE_INFO_MENU_OPTION_3" = "Copy Display name";
 "COPY_PROFILE_INFO_MENU_OPTION_4" = "Copy URL in the bio";
 "COPY_PROFILE_INFO_MENU_OPTION_5" = "Copy Location in the bio";
 


### PR DESCRIPTION
Change the "Copy Full username" to "Copy Display Name" to better fit the usage.

I changed it in Arabic and English cuz these are the langs I speak.

I think this is a better way to describe the button's functionality.